### PR TITLE
Fix 'Number too big' weirdness

### DIFF
--- a/repeatMacro.py
+++ b/repeatMacro.py
@@ -11,8 +11,8 @@ class RepeatMacroCommand(sublime_plugin.TextCommand):
     def __execute(self, text):
         if not text.isdigit() and len(text) > 0:
             print("Repeat Macro | Wrong number")
-        elif len(text) > 0 and int(text) > (self.__get_last_line() - self.__get_current_line()):
-            print("Repeat Macro | Number too big (bigger than number of lines in file)")
+        # elif len(text) > 0 and int(text) > (self.__get_last_line() - self.__get_current_line()):
+        #     print("Repeat Macro | Number too big (bigger than number of lines in file)")
         else:
             current_line = self.__get_current_line()
             last_line = current_line + int(text) if len(text) > 0 else self.__get_last_line()


### PR DESCRIPTION
Thank you for writing this plugin! But I thought your "number too big" warning makes it useless for most use cases. I just want to create a list for a blank file and it simply didn't work. I commented two lines of your code and it now worked like a charm.